### PR TITLE
Add mkdocs.

### DIFF
--- a/assets/Lapidary.css
+++ b/assets/Lapidary.css
@@ -1,0 +1,3 @@
+div.wy-menu-vertical ul.current li.toctree-l3 a {
+  font-weight: bold;
+}

--- a/assets/mathjaxhelper.js
+++ b/assets/mathjaxhelper.js
@@ -1,0 +1,8 @@
+MathJax.Hub.Config({
+  "tex2jax": { inlineMath: [ [ '$', '$' ] ] }
+});
+MathJax.Hub.Config({
+  config: ["MMLorHTML.js"],
+  jax: ["input/TeX", "output/HTML-CSS", "output/NativeMML"],
+  extensions: ["MathMenu.js", "MathZoom.js"]
+});

--- a/docs/build/Lapidary.css
+++ b/docs/build/Lapidary.css
@@ -1,0 +1,3 @@
+div.wy-menu-vertical ul.current li.toctree-l3 a {
+  font-weight: bold;
+}

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -1,0 +1,141 @@
+<a id='Main.Lapidary-1'></a>
+
+<a href='#Main.Lapidary-1'> # </a>**Constant**
+
+# Lapidary
+
+A documentation generator for Julia.
+
+[![Build Status](https://travis-ci.org/MichaelHatherly/Lapidary.jl.svg?branch=master)](https://travis-ci.org/MichaelHatherly/Lapidary.jl) [![codecov.io](http://codecov.io/github/MichaelHatherly/Lapidary.jl/coverage.svg?branch=master)](http://codecov.io/github/MichaelHatherly/Lapidary.jl?branch=master)
+
+## Brief Overview
+
+**Doctests**
+
+Any code block with `.language` set to `"julia"` containing either REPL prompts, `julia>`, or an `# output:` comment. For example:
+
+```
+    ```julia
+    julia> a = 1
+    1
+
+    julia> b = 2;
+
+    julia> a + b
+    3
+    ```
+```
+
+or
+
+```
+    ```julia
+    a = 1
+    b = 2
+    a + b
+
+    # output:
+
+    3
+    ```
+```
+
+Errors can be checked for using the `{throws ErrorName}` syntax, i.e.
+
+```
+    ```julia
+    julia> div(1, 0)
+
+        {throws DivideError}
+
+    ```
+```
+
+**Docstring Splicing**
+
+Docstrings for objects documented using Julia's docsystem can be spliced into the markdown files using code blocks containing `{docs}` as their first line:
+
+```
+```
+{docs}
+foo
+bar
+baz
+```
+```
+
+Operators must be enclosed, i.e. `(+)`.
+
+**Metadata**
+
+Metadata, such as the current module, can be set for a page using the `{meta}` code block:
+
+```
+```
+{meta}
+CurrentModule = Base
+```
+```
+
+Changing the module allows one to avoid having to fully qualify every object spliced into a `{docs}` block.
+
+**Contents & Index**
+
+Table of contents and docstring indexes can be automatically generated using either `{contents}` or `{index}` code blocks. These code blocks shouldn't contain any other text.
+
+```
+```
+{contents}
+```
+```
+
+expands to a nested list of all headers in all files found in the `src` directory. The depth of headers to be displayed can be set with
+
+```
+```
+{meta}
+ContentsDepth = 2
+```
+```
+
+prior to the `{contents}` block.
+
+```
+```
+{index}
+```
+```
+
+expands into a list of all documented objects spliced into the files found in the `src` directory. The module's to be included can be limited using
+
+```
+```
+{meta}
+IndexModules = [Foo, Bar]
+```
+```
+
+prior to the `{index}` block.
+
+**Auto Links**
+
+Automatic cross-referencing uses markdown link syntax with the `url` set to `{ref}`, i.e
+
+```
+This is the [Introduction]({ref}).
+```
+
+which links to the first header called `"Introduction"` in any file found in `src`.
+
+Spliced docstrings can be linked to using inline code syntax for the text of a link, i.e
+
+```
+This is the [`foo`]({ref}) function.
+```
+
+which will link to where `foo` was spliced into a `{docs}` block.
+
+**Building Docs**
+
+See the `src/build.jl` file for the standard build file used by Lapidary.
+<hr></hr>

--- a/docs/build/internals.md
+++ b/docs/build/internals.md
@@ -12,7 +12,7 @@ process!(doc::Document)
 
 Process a `Document` object by calling each `pass` from `doc.passes` on it in turn.
 
-A `pass` consistens of a sequence of [`AbstractAction`](internals.md#Lapidary.AbstractAction-1)s each of which apply a single transformation to the `doc` object such as autolinking cross-references found in the pages of the `Document` or running doctests on all the code blocks.
+A `pass` consists of a sequence of [`AbstractAction`](internals.md#Lapidary.AbstractAction-1)s each of which apply a single transformation to the `doc` object such as autolinking cross-references found in the pages of the `Document` or running doctests on all the code blocks.
 <hr></hr>
 <a id='Lapidary.AbstractAction-1'></a>
 

--- a/docs/build/mathjaxhelper.js
+++ b/docs/build/mathjaxhelper.js
@@ -1,0 +1,8 @@
+MathJax.Hub.Config({
+  "tex2jax": { inlineMath: [ [ '$', '$' ] ] }
+});
+MathJax.Hub.Config({
+  config: ["MMLorHTML.js"],
+  jax: ["input/TeX", "output/HTML-CSS", "output/NativeMML"],
+  extensions: ["MathMenu.js", "MathZoom.js"]
+});

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,2 @@
+    {docs}
+    Lapidary

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name:           Lapidary.jl
+repo_url:            https://github.com/MichaelHatherly/Lapidary.jl
+site_description:    Julia package documentation generator.
+site_author:         Michael Hatherly
+
+theme:               readthedocs
+extra_css:
+  - Lapidary.css
+
+markdown_extensions:
+  - extra
+  - tables
+  - fenced_code
+extra_javascript:
+  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - mathjaxhelper.js
+
+docs_dir: 'docs/build'
+pages:
+  - 'About': index.md
+  - 'Public': public.md
+  - 'Internals': internals.md

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -6,7 +6,7 @@
 
 Process a `Document` object by calling each `pass` from `doc.passes` on it in turn.
 
-A `pass` consistens of a sequence of [`AbstractAction`]({ref})s each of which apply a single
+A `pass` consists of a sequence of [`AbstractAction`]({ref})s each of which apply a single
 transformation to the `doc` object such as autolinking cross-references found in the pages
 of the `Document` or running doctests on all the code blocks.
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -41,6 +41,13 @@ immutable Document
                 doc.pagemap[obj] = page
             end
         end
+        assetdir = normpath(joinpath(dirname(@__FILE__), "..", "assets"))
+        for asset in readdir(assetdir)
+            obj, out = paths(assetdir, asset, assetdir, build)
+            page = Page(doc, obj, out, format)
+            push!(doc.pages, page)
+            doc.pagemap[obj] = page
+        end
         doc
     end
 end


### PR DESCRIPTION
This also adds two static files to the build:
- mathjaxhelper.js (determine what mathjax sees as latex)
- Lapidary.css (for the moment this fixes a small annoyance which I have with mathjax rendering of LHS nav, but potentially could do some other julia-specific tweaks).