### PR TITLE
fix REPL test when there is a semicolon before a comment

### DIFF
--- a/docs/src/man/doctests.md
+++ b/docs/src/man/doctests.md
@@ -43,13 +43,15 @@ detected by Lapidary as a REPL doctest:
 
 ````markdown
 ```julia
-julia> a = 1;
+julia> a = 1
+1
 
-julia> b = 2
-2
+julia> b = 2;
 
-julia> a + b
-3
+julia> c = 3;  # comment
+
+julia> a + b + c
+6
 
 ```
 ````

--- a/src/modules/DocChecks.jl
+++ b/src/modules/DocChecks.jl
@@ -119,14 +119,26 @@ function eval_repl(code, sandbox)
             try
                 ans = eval(sandbox, ex)
                 eval(sandbox, :(ans = $(ans)))
-                endswith(strip(p[1:cursor-1]), ';') ?
-                    "" : result_to_string(ans)
+                ends_with_semicolon(p) ? "" : result_to_string(ans)
             catch err
                 error_to_string(err, catch_backtrace())
             end
         checkresults(code, part, p[cursor:end], result)
     end
 end
+
+# from base/REPL.jl
+function ends_with_semicolon(line)
+    match = rsearch(line, ';')
+    if match != 0
+        for c in line[(match+1):end]
+            isspace(c) || return c == '#'
+        end
+        return true
+    end
+    return false
+end
+
 function eval_script(code, sandbox)
     code, expected = split(code, "\n# output\n", limit = 2)
     result =


### PR DESCRIPTION
This fixes REPL test when there is a semicolon before a comment. In Julia's REPL, output is suppressed when there is a semicolon before a comment like below:

```julia
julia> [1,2,3];  # comment

```

This behavior was not reflected in Lapidary.jl, so I fixed it.